### PR TITLE
Updating installer scripts, add optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,34 @@
 # Installation of miniconda3, miniconda3 module for Lmod module environment (Lua-based), and conda environements (e.g., regional_workflow)
 
-Last revision: July 5, 2023  (update as needed) @natalie-perlin 
-
 1. Find a right installer script to download from **URL="https://repo.anaconda.com/miniconda"**, or determine its correct name, e.g., `Miniconda3-py39_4.12.0-Linux-x86_64.sh`
 
-2. Configure the installation script **miniconda3_install.sh** as follows:
-
-   a) BASH_ENV  - Lmod initialization script to be sourced, e.g.,
-                `BASH_ENV=/apps/lmod/lmod/init/bash`
-                
-                
-   b) installer - installer name to use or download from the URL (as in step 1).  
+2. Modify a wrapper script **miniconda3_install.sh**, if needed, to specify the installer script name to use or download from the URL (as in step 1).  
           e.g., `installer="Miniconda3-py39_4.12.0-Linux-x86_64.sh"`
-          
-   c) version   - miniconda3 version
-          e.g., `version="4.12.0"`
-          
-   d) PREFIX0  - a local installation path of the miniconda3, for all versions;
-      PREFIX   - a local installation path for a particular version, e.g.,
-                `PREFIX0="/home/miniconda3"`, 
-                `PREFIX="${PREFIX0}/${version}"`
-                
-   e) verify the modulefile **miniconda3template.lua** template is present in a directory from which the scrips is lauched, and specify a target modulefile location for miniconda3, e.g.,
-               `MODULEFILES="$PREFIX0/modulefiles"`
 
-3. Configure the modulefile *miniconda3template.lua* and specify a local prefix, e.g.,
-       `local prefix = pathJoin("/home",pkgName)`
+3. Verify that a modulefile **miniconda3template.lua** template is present in a directory from which the runscript is lauched.
 
-4. Run the installation script wrapper: 
-   `./miniconda3_install.sh 2>&1 | tee log.miniconda_install`
+4. Run the installation script wrapper, with optional arguments:
+    (1) installation directory,  (2) conda version 
+   E.g,: `./miniconda3_install.sh /lustre/miniconda  4.12.0 `
    
 5. Create a **regional_workflow** environment with the packages needed to run the UFS-SRW
    App and to use graphic packages for plotting. Packages to be installed are listed
    in `regional_workflow.yaml` file that is expected to be present in the same 
    directory as the installation script  **miniconda3_regional_workflow_env.sh**.   
-   Configure the env. varialbles in the script similar to Step 2,
-   and then launch it:   
-   `./miniconda3_regional_workflow_env.sh 2>&1 | tee log.regional_workflow_install`
+   Launch it and provide optional arguments similar to Step 4, e.g.:
+   `./miniconda3_regional_workflow_env.sh  /lustre/miniconda  4.12.0 `
+
 6. Create a **workflow_toos** environment with the packages for the updated UFS-SRW
    Packages to be installed are listed
    in `workflow_tools.yaml` file that is expected to be present in the same 
    directory as the installation script  **miniconda3_workflow_tools_env.sh**.   
-   Configure the env. varialbles in the script similar to Step 2 and 5,
-   and then launch it:   
-   `./miniconda3_workflow_tools_env.sh 2>&1 | tee log.workflow_tools_install`
-6. Create a **regional_workflow_cmaq** environment with the packages for UFS-SRW
+   Launch it and provide optional arguments similar to Steps 4-5, e.g.:
+   `./miniconda3_workflow_tools_env.sh  /lustre/miniconda  4.12.0 `
+
+7. Create a **regional_workflow_cmaq** environment with the packages for UFS-SRW
    and for Air Quality Management module (Online-CMAQ).
    Packages to be installed are listed
    in `regional_workflow_cmaq.yaml` file that is expected to be present in the same 
    directory as the installation script  **miniconda3_regional_workflow_cmaq_env.sh**.   
-   Configure the env. varialbles in the script similar to Step 2 and 5,
-   and then launch it:   
-   `./miniconda3_regional_workflow_cmaq_env.sh 2>&1 | tee log.regional_workflow_cmaq_install`
+   Launch it and provide optional arguments similar to Steps 4-6, e.g.:
+   `./miniconda3_regional_workflow_cmaq_env.sh /lustre/miniconda  4.12.0 `

--- a/miniconda3_install.sh
+++ b/miniconda3_install.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 # Initialize Lmod:
-export BASH_ENV=/apps/lmod/lmod/init/profile
-source $BASH_ENV
+echo $LMOD_PKG 
+ENV=$LMOD_PKG/init/profile
+source $ENV
+export BASH_ENV=$LMOD_PKG/init/bash
 #
 set -x
+name="miniconda3"
+version="4.12.0"
+PREFIX0=${1:-"/lustre/$name"}
+PREFIX="${PREFIX0}/${version}"
 URL="https://repo.anaconda.com/miniconda"
 installer="Miniconda3-py39_4.12.0-Linux-x86_64.sh"
-version="4.12.0"
 [[ -f "$installer" ]] || wget -nv $URL/$installer
 # The PREFIX below is the target installation, try local directory first
-PREFIX0="/lustre/miniconda3"
-PREFIX="${PREFIX0}/${version}"
 [[ -d $PREFIX ]] && echo "Directory $PREFIX exists"
 bash $installer -b -p $PREFIX -s
 export CONDA_ROOT=$PREFIX
@@ -42,4 +45,7 @@ conda install -y git-lfs
 TEMPLATES=$PWD
 MODULEFILES="${PREFIX0}/modulefiles"
 [[ -d "${MODULEFILES}/miniconda3" ]] || mkdir -p ${MODULEFILES}/miniconda3/
-[[ -f "${TEMPLATES}/miniconda3template.lua" ]] && cp -v ${TEMPLATES}/miniconda3template.lua  ${MODULEFILES}/miniconda3/${version}.lua
+if [[ -f "${TEMPLATES}/miniconda3template.lua" ]]; then
+  sed "s|local prefix.*|local prefix=\"$PREFIX0\"|" ${TEMPLATES}/miniconda3template.lua  >  ${MODULEFILES}/miniconda3/${version}.lua
+fi  
+echo "Finished installation of $name, version $version"

--- a/miniconda3_regional_workflow_cmaq_env.sh
+++ b/miniconda3_regional_workflow_cmaq_env.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Initialize Lmod:
-export BASH_ENV=/apps/lmod/lmod/init/profile
-source $BASH_ENV
+echo $LMOD_PKG
+ENV=$LMOD_PKG/init/profile
+source $ENV
+export BASH_ENV=$LMOD_PKG/init/bash
 #
-PREFIX0="/lustre/miniconda3"
-version="4.12.0"
+PREFIX0=${1:-"/lustre/miniconda3"}
+version=${2:-"4.12.0"}
 MODULEFILES="${PREFIX0}/modulefiles"
 module use $MODULEFILES
 module avail miniconda3

--- a/miniconda3_regional_workflow_env.sh
+++ b/miniconda3_regional_workflow_env.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Initialize Lmod:
-export BASH_ENV=/apps/lmod/lmod/init/profile
-source $BASH_ENV
+echo $LMOD_PKG
+ENV=$LMOD_PKG/init/profile
+source $ENV
+export BASH_ENV=$LMOD_PKG/init/bash
 #
-PREFIX0="/lustre/miniconda3"
-version="4.12.0"
+PREFIX0=${1:-"/lustre/miniconda3"}
+version=${2:-"4.12.0"}
 MODULEFILES="${PREFIX0}/modulefiles"
 module use $MODULEFILES
 module avail miniconda3

--- a/miniconda3_workflow_tools_env.sh
+++ b/miniconda3_workflow_tools_env.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Initialize Lmod:
-export BASH_ENV=/apps/lmod/lmod/init/profile
-source $BASH_ENV
+echo $LMOD_PKG
+ENV=$LMOD_PKG/init/profile
+source $ENV
+export BASH_ENV=$LMOD_PKG/init/bash
 #
-PREFIX0="/lustre/miniconda3"
-version="4.12.0"
+PREFIX0=${1:-"/lustre/miniconda3"}
+version=${2:-"4.12.0"}
 MODULEFILES="${PREFIX0}/modulefiles"
 module use $MODULEFILES
 module avail miniconda3


### PR DESCRIPTION
Updated installer scripts:
```
miniconda3_install.sh
miniconda3_regional_workflow_env.sh
miniconda3_workflow_tools_env.sh
miniconda3_regional_workflow_cmaq_env.sh
```
- Query existing $LMOD_PKG to run shell initialization
- Use optional arguments for the installation scripts: 
  (1) installation directory, default is /lustre/miniconda3;
  (2) conda version to install; default is 4.12.0
- Updated README.md file to reflect recent changes
