### PR TITLE
correction to regional_workflow.yaml to allow plotting tasks

### DIFF
--- a/regional_workflow.yaml
+++ b/regional_workflow.yaml
@@ -10,4 +10,4 @@ dependencies:
   - scipy
   - matplotlib=3.5.2*
   - pygrib
-  - cartopy
+  - cartopy=0.18.0


### PR DESCRIPTION
Specify version of cartopy=0.18.0 package in `regional_workflow.yaml `to fix issues with plotting routines. It is requiered to work along with matplotlib=3.5.2